### PR TITLE
Use nightlies for Edifice versions

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -24,6 +24,55 @@ repositories:
 # wildcards are allowed in name, entries are processed in top-down order
 # first entry matching the name is used
 projects:
+    # Use prerelease + nightly in all edifice new major versions
+    - name: ignition-edifice
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
+          - name: osrf
+            type: nightly
+    - name: ignition-gazebo5
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
+          - name: osrf
+            type: nightly
+    - name: ignition-gui5
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
+          - name: osrf
+            type: nightly
+    - name: ignition-rendering5
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
+          - name: osrf
+            type: nightly
+    - name: ignition-sensors5
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
+          - name: osrf
+            type: nightly
+    - name: ignition-launch4
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
+          - name: osrf
+            type: nightly
     # generic regexp
     - name: gazebo.*
       repositories:


### PR DESCRIPTION
Use nightlies for `ignition-edifice` to fix https://build.osrfoundation.org/job/ignition_edifice-install-pkg-focal-amd64/6/

Also use nightlies for `ign-rendering5` and its dependencies, see https://github.com/ignition-tooling/release-tools/issues/331.