### PR TITLE
sdformat11: use prereleases for now

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -73,6 +73,12 @@ projects:
             type: prerelease
           - name: osrf
             type: nightly
+    - name: sdformat11
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
     # generic regexp
     - name: gazebo.*
       repositories:


### PR DESCRIPTION
osrf/sdformat#434 needs ignition-math 6.8.0~pre1

cc @brawner