### PR TITLE
Remove nightlies for Edifice

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -24,103 +24,79 @@ repositories:
 # wildcards are allowed in name, entries are processed in top-down order
 # first entry matching the name is used
 projects:
-    # Use prerelease + nightly in all edifice new major versions
+    # Use prerelease in all edifice new major versions
     - name: ignition-edifice
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: prerelease
-          - name: osrf
-            type: nightly
     - name: ignition-common4
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: prerelease
-          - name: osrf
-            type: nightly
     - name: ignition-fuel-tools6
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: prerelease
-          - name: osrf
-            type: nightly
     - name: ignition-gazebo5
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: prerelease
-          - name: osrf
-            type: nightly
     - name: ignition-gui5
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: prerelease
-          - name: osrf
-            type: nightly
     - name: ignition-msgs7
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: prerelease
-          - name: osrf
-            type: nightly
     - name: ignition-rendering5
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: prerelease
-          - name: osrf
-            type: nightly
     - name: ignition-sensors5
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: prerelease
-          - name: osrf
-            type: nightly
     - name: ignition-transport10
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: prerelease
-          - name: osrf
-            type: nightly
     - name: ignition-launch4
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: prerelease
-          - name: osrf
-            type: nightly
     - name: ignition-physics4
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: prerelease
-          - name: osrf
-            type: nightly
     - name: sdformat11
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: prerelease
-          - name: osrf
-            type: nightly
     # generic regexp
     - name: gazebo.*
       repositories:


### PR DESCRIPTION
We have pre-releases of all Edifice libraries, so we don't need to use the pre-release repos anymore.