### PR TITLE
Use nightlies on all main branches

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -24,6 +24,103 @@ repositories:
 # wildcards are allowed in name, entries are processed in top-down order
 # first entry matching the name is used
 projects:
+    # Use nightlies in all main branches
+    - name: ignition-fortress
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: ignition-cmake3
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: ignition-common5
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: ignition-fuel-tools7
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: ignition-gazebo6
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: ignition-gui6
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: ignition-launch5
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: ignition-msgs8
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: ignition-physics5
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: ignition-plugin2
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: ignition-rendering6
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: ignition-sensors6
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: ignition-tools2
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: ignition-transport11
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: ignition-utils2
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: sdformat12
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
     # generic regexp
     - name: gazebo.*
       repositories:

--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -31,18 +31,6 @@ projects:
             type: stable
           - name: osrf
             type: nightly
-    - name: ignition-cmake3
-      repositories:
-          - name: osrf
-            type: stable
-          - name: osrf
-            type: nightly
-    - name: ignition-common5
-      repositories:
-          - name: osrf
-            type: stable
-          - name: osrf
-            type: nightly
     - name: ignition-fuel-tools7
       repositories:
           - name: osrf
@@ -79,12 +67,6 @@ projects:
             type: stable
           - name: osrf
             type: nightly
-    - name: ignition-plugin2
-      repositories:
-          - name: osrf
-            type: stable
-          - name: osrf
-            type: nightly
     - name: ignition-rendering6
       repositories:
           - name: osrf
@@ -97,19 +79,7 @@ projects:
             type: stable
           - name: osrf
             type: nightly
-    - name: ignition-tools2
-      repositories:
-          - name: osrf
-            type: stable
-          - name: osrf
-            type: nightly
     - name: ignition-transport11
-      repositories:
-          - name: osrf
-            type: stable
-          - name: osrf
-            type: nightly
-    - name: ignition-utils2
       repositories:
           - name: osrf
             type: stable


### PR DESCRIPTION
Part of https://github.com/ignition-tooling/release-tools/issues/428.

Some of these are not strictly necessary yet, some of them may never be necessary. Nevertheless, I find it easier to have a rule that we apply to all main branches rather than having to analyze case by case. It shouldn't hurt that `ign-cmake3` loads nightlies even though it doesn't use (for now) anything from there.

I propose the following workflow:

1. Beginning of development cycle: all main branches use nightlies
1. Feature freeze: as pre-releases start to be made, swap `nightly` for `prerelease`
1. Code freeze: after stable releases are made, bump all main branches to the next versions and go back to 1. :point_up: 

---

## Update

Reverted the idea above for now, so this PR has only the branches that are known to go into Fortress. I think that having a more standard approach across the main branches will save us time, but I understand that this may cause confusion and not everyone is onboard, so I'm shelving this idea for now.