### PR TITLE
add fortress support to ign-docker-env

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ pytest
 pyyaml
 git+https://github.com/osrf/rocker.git#egg=rocker
 git+https://github.com/adlarkin/ign-rocker.git#egg=ign-rocker
+# needed to patch a broken dependency in docker-py (see https://github.com/docker/docker-py/pull/2844)
+# this can be removed once the PR linked above is merged
+six==1.16.0


### PR DESCRIPTION
requires https://github.com/adlarkin/ign-rocker/pull/2 (@j-rivero, I wasn't able to request you as a reviewer for this PR, but if you want to try it before I merge, let me know if you see any issues. I have tested it, and it seems to work fine)

I've added fortress support to `ign-docker-env` and have also added some error checking to make sure that users pass in a valid argument for the ignition version.

Signed-off-by: Ashton Larkin <ashton@openrobotics.org>