### PR TITLE
Revert pre-releases for gazebo5

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -91,13 +91,6 @@ projects:
             type: stable
           - name: osrf
             type: nightly
-    # prereleases for ignition-gazebo5
-    - name: ignition-gazebo5
-      repositories:
-          - name: osrf
-            type: stable
-          - name: osrf
-            type: prerelease
     # generic regexp
     - name: gazebo.*
       repositories:


### PR DESCRIPTION
Reverting #33. Testing the https://github.com/ignitionrobotics/ign-physics/pull/277 pre-release with https://github.com/ignitionrobotics/ign-gazebo/pull/661 worked well and we're ready for a stable release in https://github.com/ignitionrobotics/ign-physics/pull/279.