### PR TITLE
Revert ign-gazebo3 prerelease

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -24,13 +24,6 @@ repositories:
 # wildcards are allowed in name, entries are processed in top-down order
 # first entry matching the name is used
 projects:
-    # needs ign-physics2 2.5 prerelease, remove after 2.5 stable release
-    - name: ignition-gazebo3
-      repositories:
-          - name: osrf
-            type: stable
-          - name: osrf
-            type: prerelease
     # generic regexp
     - name: gazebo.*
       repositories:


### PR DESCRIPTION
ign-physics 2.5 has been released, so revert ign-gazebo to stable.