### PR TITLE
Bumps in garden: ign-math7

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -55,6 +55,12 @@ projects:
             type: stable
           - name: osrf
             type: nightly
+    - name: ignition-math7
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
     - name: ignition-sensors7
       repositories:
           - name: osrf

--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -56,6 +56,7 @@ projects:
           - name: osrf
             type: nightly
     - name: ignition-math7
+      repositories:
           - name: osrf
             type: stable
           - name: osrf


### PR DESCRIPTION
This is not strictly necessary now, but it's future-proofing in case we bump any of `ign-math`'s dependencies

See https://github.com/ignition-tooling/release-tools/issues/574