### PR TITLE
Use nightlies for all main branches

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -25,6 +25,12 @@ repositories:
 # first entry matching the name is used
 projects:
     # Use nightlies in all main branches
+    - name: ignition-cmake3
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
     - name: ignition-common5
       repositories:
           - name: osrf
@@ -79,6 +85,12 @@ projects:
             type: stable
           - name: osrf
             type: nightly
+    - name: ignition-plugin2
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
     - name: ignition-rendering7
       repositories:
           - name: osrf
@@ -91,7 +103,19 @@ projects:
             type: stable
           - name: osrf
             type: nightly
+    - name: ignition-tools2
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
     - name: ignition-transport12
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: ignition-utils2
       repositories:
           - name: osrf
             type: stable


### PR DESCRIPTION
Revisiting an idea which was originally introduced in https://github.com/ignition-tooling/gzdev/pull/31, but eventually reverted.

* Current approach: use nightlies when a `main` branch is known to go into the upcoming collection
    * Cons:
        * It's one more PR to open as part of a dependency bumping process, which is already complicated as it is
        * We often refrain from adding the nighlies for a `main` branch while bumping if we know that it won't be immediately necessary. This means we need to track it back when it is necessary, causing more churn. See https://github.com/ignition-tooling/gzdev/pull/31
    * Pros:
        * Only use nightlies when strictly necessary, so if we see nightlies enabled, we know they're needed
* Suggestion: use nightlies for all `main` branches
    * Cons:
        * We lose the nuance of whether nightlies are actually necessary or not
    * Pros:
        * Easier to maintain, we can just do for all branches the moment we fork `ign-XN` from `main`, which would be part of the post-release process: https://github.com/ignition-tooling/release-tools/blob/master/.github/ISSUE_TEMPLATE/release_collection.md#post-release

