### PR TITLE
Adjust usage of distro for new API

### DIFF
--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -74,17 +74,18 @@ def load_project(project, config):
 def get_linux_distro_version():
     # Handle both: distro module and old platform
     try:
-        return distro.linux_distribution()[2]
+        return distro.codename()
     except NameError:
         return platform.linux_distribution()[2]
 
 def get_linux_distro():
     # Handle both: distro module and old platform
     try:
-        distro_str = distro.linux_distribution()[0]
+        distro_str = distro.id()
     except NameError:
         distro_str = platform.linux_distribution()[0]
 
+    # Probably not necessary with distro.id, but retained for compatibility
     if "Debian" in distro_str:
         return "debian"
     elif "Ubuntu" in distro_str:


### PR DESCRIPTION
`distro` recently updated to 1.7.0, which changed how some of the APIs work.

First, `linux_distribution()` is deprecated, and it is now returning the codename differently

```
In [5]: distro.__version__                                                                                                                 
Out[5]: '1.7.0'

In [6]: distro.linux_distribution()                                                                                                        
<ipython-input-6-ac24b2663c5c>:1: DeprecationWarning: distro.linux_distribution() is deprecated. It should only be used as a compatibility shim with Python's platform.linux_distribution(). Please use distro.id(), distro.version() and distro.name() instead.
  distro.linux_distribution()
Out[6]: ('Ubuntu', '20.04', 'Focal Fossa')
```

Instead, we should be using `distro.codename()` and `distro.id()` to get the correct behavior

Signed-off-by: Michael Carroll <michael@openrobotics.org>