### PR TITLE
Remove EOL Dome and Edifice from ign-docker-env tool

### DIFF
--- a/plugins/ign-docker-env.py
+++ b/plugins/ign-docker-env.py
@@ -33,7 +33,7 @@ Options:
     --vol $LOCAL_PATH:$CONTAINER_PATH   Load volumes into Docker container (separate multiple volumes with '::')
 
 Notes:
-    Valid inputs for IGN_RELEASE are 'citadel', 'dome', 'edifice', and 'fortress'.
+    Valid inputs for IGN_RELEASE are 'citadel' and 'fortress'.
     Valid inputs for the --linux-distro arg are 'ubuntu:bionic' or 'ubuntu:focal'.
 """
 
@@ -53,8 +53,6 @@ bionic = 'ubuntu:bionic'
 focal = 'ubuntu:focal'
 IGN_VERSIONS = {
     'citadel': bionic,
-    'dome': bionic,
-    'edifice': focal,
     'fortress': focal
 }
 


### PR DESCRIPTION
Since Dome and Edifice are now EOL, we should not allow users to pick one of these Ignition versions when using the `ign-docker-env` tool.

Signed-off-by: Ashton Larkin <42042756+adlarkin@users.noreply.github.com>