### PR TITLE
Support for renaming ign to gz names

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -25,97 +25,97 @@ repositories:
 # first entry matching the name is used
 projects:
     # Use nightlies in all main branches
-    - name: gazebo-cmake3
+    - name: gz-cmake3
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: nightly
-    - name: gazebo-common5
+    - name: gz-common5
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: nightly
-    - name: gazebo-fuel-tools8
+    - name: gz-fuel-tools8
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: nightly
-    - name: gazebo-garden
+    - name: gz-garden
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: nightly
-    - name: gazebo-gazebo7
+    - name: gz-gazebo7
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: nightly
-    - name: gazebo-gui7
+    - name: gz-gui7
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: nightly
-    - name: gazebo-launch6
+    - name: gz-launch6
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: nightly
-    - name: gazebo-math7
+    - name: gz-math7
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: nightly
-    - name: gazebo-msgs9
+    - name: gz-msgs9
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: nightly
-    - name: gazebo-physics6
+    - name: gz-physics6
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: nightly
-    - name: gazebo-plugin2
+    - name: gz-plugin2
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: nightly
-    - name: gazebo-rendering7
+    - name: gz-rendering7
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: nightly
-    - name: gazebo-sensors7
+    - name: gz-sensors7
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: nightly
-    - name: gazebo-tools2
+    - name: gz-tools2
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: nightly
-    - name: gazebo-transport12
+    - name: gz-transport12
       repositories:
           - name: osrf
             type: stable
           - name: osrf
             type: nightly
-    - name: gazebo-utils2
+    - name: gz-utils2
       repositories:
           - name: osrf
             type: stable
@@ -127,7 +127,7 @@ projects:
             type: stable
           - name: osrf
             type: nightly
-    - name: gazebo-gazebo6
+    - name: gz-gazebo6
       repositories:
           - name: osrf
             type: stable
@@ -242,7 +242,7 @@ projects:
       repositories:
           - name: osrf
             type: stable
-    - name: gazebo-.*
+    - name: gz-.*
       repositories:
           - name: osrf
             type: stable

--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -49,7 +49,7 @@ projects:
             type: stable
           - name: osrf
             type: nightly
-    - name: gz-gazebo7
+    - name: gz-sim7
       repositories:
           - name: osrf
             type: stable

--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -25,6 +25,116 @@ repositories:
 # first entry matching the name is used
 projects:
     # Use nightlies in all main branches
+    - name: gazebo-cmake3
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: gazebo-common5
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: gazebo-fuel-tools8
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: gazebo-garden
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: gazebo-gazebo7
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: gazebo-gui7
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: gazebo-launch6
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: gazebo-math7
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: gazebo-msgs9
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: gazebo-physics6
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: gazebo-plugin2
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: gazebo-rendering7
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: gazebo-sensors7
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: gazebo-tools2
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: gazebo-transport12
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: gazebo-utils2
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: sdformat13
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: nightly
+    - name: gazebo-gazebo6
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
+    # TOOD(jrivero): remove when the renaming of ign to gz
+    # Use nightlies in all main branches
     - name: ignition-cmake3
       repositories:
           - name: osrf
@@ -132,6 +242,11 @@ projects:
       repositories:
           - name: osrf
             type: stable
+    - name: gazebo-.*
+      repositories:
+          - name: osrf
+            type: stable
+    # TOOD(jrivero): remove when the renaming of ign to gz
     - name: ignition-.*
       repositories:
           - name: osrf

--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -127,12 +127,6 @@ projects:
             type: stable
           - name: osrf
             type: nightly
-    - name: gz-gazebo6
-      repositories:
-          - name: osrf
-            type: stable
-          - name: osrf
-            type: prerelease
     # TOOD(jrivero): remove when the renaming of ign to gz
     # Use nightlies in all main branches
     - name: ignition-cmake3


### PR DESCRIPTION
Add duplicate entries for ignition packages to support the rename of them to gazebo.
