### PR TITLE
Disable prereleases on ign-gazebo6

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -127,12 +127,6 @@ projects:
             type: stable
           - name: osrf
             type: nightly
-    - name: ignition-gazebo6
-      repositories:
-          - name: osrf
-            type: stable
-          - name: osrf
-            type: prerelease
     # generic regexp
     - name: gazebo.*
       repositories:


### PR DESCRIPTION
Reverting #55 now that https://github.com/ignitionrobotics/ign-gazebo/pull/1333 is merged.

CC @nkoenig 